### PR TITLE
system/mcperf: explicitly set server to 127.0.0.1

### DIFF
--- a/system/mcperf-1.3.0/test-definition.xml
+++ b/system/mcperf-1.3.0/test-definition.xml
@@ -23,7 +23,7 @@
   </TestProfile>
   <TestSettings>
     <Default>
-      <Arguments>--linger=0 --call-rate=0 --num-calls=1000000 --conn-rate=0 --sizes=d5120</Arguments>
+      <Arguments>--server=127.0.0.1 --linger=0 --call-rate=0 --num-calls=1000000 --conn-rate=0 --sizes=d5120</Arguments>
     </Default>
     <Option>
       <DisplayName>Method</DisplayName>


### PR DESCRIPTION
The memcached server listens on 127.0.0.1 by default on some Linux
distros such as Ubuntu 20.04, while mcperf connects to localhost if the
server parameter is not provided. In some cases localhost may resolve to
the ipv6 address instead of 127.0.0.1 and result in a connection error.
This change set the server to 127.0.0.1 explicitly.